### PR TITLE
Add npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+packages/list-packages-by-directory/__fixtures__/*

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-packages/list-packages-by-directory/__fixtures__/*

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint": "eslint . --ext '.ts' --fix",
     "lint:ci": "eslint . --ext '.ts'",
     "test": "jest --maxWorkers=4 --collectCoverage=true --testTimeout=15000 --detectOpenHandles",
-    "deploy": "pnpm run build && pnpm -r publish --access public",
+    "deploy": "pnpm run build && pnpm -r publish --filter=!./packages/list-packages-by-directory/__fixtures__/ --access public",
     "preinstall": "npx only-allow pnpm",
     "tsc": "tsc -p ./tsconfig.test.json"
   },


### PR DESCRIPTION
## Fixes

- Fixes issue with npm trying to publish test `package.json`'s
- I thought it was going to be `.npmignore`, but alas, it was just using pnpm's filter option 🔥 


---

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
